### PR TITLE
Release workflow: add dry run mode and refactor version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,31 +1,87 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run mode (skip tag push and npm publish)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
+  contents: write
   id-token: write
 
 jobs:
-  publish-npm:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: ./.github/actions/setup-devenv
 
-      - name: Check version match
+      - name: Get version from package.json
+        id: version
         run: |
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          TAG_VERSION="${{ github.event.release.tag_name }}"
-          # Remove 'v' prefix if present
-          TAG_VERSION="${TAG_VERSION#v}"
+          VERSION="$(node -p 'require("./package.json").version')"
+          echo "Version from package.json: $VERSION"
 
-          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
-            echo "Error: package.json version ($PACKAGE_VERSION) does not match release tag ($TAG_VERSION)"
+          # Check if tag already exists
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Error: Tag v$VERSION already exists"
             exit 1
           fi
-          echo "Version check passed: $PACKAGE_VERSION"
 
-      - run: devenv shell npm run build
-      - run: devenv shell npm publish
+          # Set output
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run tests
+        run: devenv shell npm test
+
+      - name: Build package
+        run: devenv shell npm run build
+
+      - name: Dry run check
+        if: ${{ github.event.inputs.dry_run == 'true' }}
+        run: |
+          echo "🔍 DRY RUN MODE - The following actions will be skipped:"
+          echo "  - Publishing to npm"
+          echo "  - Creating and pushing git tag"
+          echo ""
+          echo "📦 Package would be published:"
+          echo "  Name: $(node -p "require('./package.json').name")"
+          echo "  Version: ${{ steps.version.outputs.version }}"
+          echo "  Tag: ${{ steps.version.outputs.tag }}"
+
+      - name: Publish to npm
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: devenv shell npm publish
+
+      - name: Create and push tag
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        run: |
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Summary
+        run: |
+          if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
+            echo "✅ Dry run completed successfully"
+            echo "  - Tests passed"
+            echo "  - Build completed"
+            echo "  - Ready to release version ${{ steps.version.outputs.version }}"
+          else
+            echo "🚀 Release completed successfully"
+            echo "  - Published version ${{ steps.version.outputs.version }} to npm"
+            echo "  - Created and pushed tag ${{ steps.version.outputs.tag }}"
+          fi


### PR DESCRIPTION
This pull request significantly refactors the release workflow to make releases safer and more flexible. The workflow is now manually triggered with support for a "dry run" mode, includes additional safety checks, and separates the build, test, and publish steps for better clarity and control.

**Release workflow improvements:**

* Changed the workflow trigger from automatic on release publication to manual (`workflow_dispatch`) with an optional `dry_run` input, allowing users to preview the release process without actually publishing or tagging.
* Added a step to check if the git tag for the version already exists, preventing accidental duplicate releases.
* Added a summary step at the end to clearly indicate the outcome of the workflow, distinguishing between dry runs and real releases.

**Process and safety enhancements:**

* Introduced steps to configure Git for tagging, run tests, and build the package before publishing, ensuring that only tested and built code is released.
* Separated the publish and tag creation steps, and made them conditional on not being in dry run mode, to avoid unintended side effects during testing.