### PR TITLE
Use Node.js v24

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1753476615,
+        "lastModified": 1754730435,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "8a92f0a645f8c6ee1653a492abc0be3556b0202d",
+        "rev": "d1388a093a7225c2abe8c244109c5a4490de4077",
         "type": "github"
       },
       "original": {
@@ -40,10 +40,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1750779888,
+        "lastModified": 1754416808,
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
         "type": "github"
       },
       "original": {
@@ -74,10 +74,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750441195,
+        "lastModified": 1754299112,
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "0ceffe312871b443929ff3006960d29b120dc627",
+        "rev": "16c21c9f5c6fb978466e91182a248dd8ca1112ac",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -12,6 +12,7 @@
 
   # https://devenv.sh/languages/
   languages.javascript = {
+    package = pkgs.nodejs-slim_24;
     enable = true;
     npm = {
       enable = true;

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -5,11 +5,3 @@ inputs:
 
 # If you're using non-OSS software, you can set allowUnfree to true.
 # allowUnfree: true
-
-# If you're willing to use a package that's vulnerable
-# permittedInsecurePackages:
-#  - "openssl-1.1.1w"
-
-# If you have more than one devenv you can merge them
-#imports:
-# - ./backend


### PR DESCRIPTION
This pull request makes a minor update to the development environment configuration by specifying a particular Node.js package version and cleaning up commented-out configuration lines.

- Development environment configuration:
  * Set the JavaScript language environment to use the `nodejs-slim_24` package in `devenv.nix`, ensuring a specific Node.js version is used for consistency.
  * Removed unused and commented-out configuration lines from `devenv.yaml` to keep the file clean and maintainable.