### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mizunashi-mana/safe-file-deletion-mcp/security/code-scanning/1](https://github.com/mizunashi-mana/safe-file-deletion-mcp/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow appears to only check out code and run tests, it likely only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow file (above `jobs:`), which will apply to all jobs unless overridden. This change should be made in `.github/workflows/test.yml` above the `jobs:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
